### PR TITLE
Make curl fail with a nicer error message

### DIFF
--- a/shelm
+++ b/shelm
@@ -68,10 +68,12 @@ json_location() {
 fetch_github_release() {
 	pkgname="$1"
 	version="$2"
-	curlargs=-sSL # no progress, show errors, follow redirects
+	curlargs=-sSLf # no progress, show errors, follow redirects, exit with error on HTTP status >=400
 	url="https://github.com/$pkgname/archive/$version.tar.gz"
 	echo "fetching $url"
-	curl "$curlargs" "$url" | tar -xz
+	tarball="$(mktemp)"
+	curl "$curlargs" "$url" >"$tarball" || exit 1
+	tar -xzf "$tarball"
 }
 
 fetch_git_ref() {

--- a/shelm
+++ b/shelm
@@ -71,9 +71,7 @@ fetch_github_release() {
 	curlargs=-sSLf # no progress, show errors, follow redirects, exit with error on HTTP status >=400
 	url="https://github.com/$pkgname/archive/$version.tar.gz"
 	echo "fetching $url"
-	tarball="$(mktemp)"
-	curl "$curlargs" "$url" >"$tarball" || exit 1
-	tar -xzf "$tarball"
+	curl "$curlargs" "$url" | tar -xz
 }
 
 fetch_git_ref() {


### PR DESCRIPTION
Prior to this, curl failure would present as an error like `tar: Error opening archive: Unrecognized archive format`.
