### PR TITLE
Remove depth from find invocation

### DIFF
--- a/shelm
+++ b/shelm
@@ -122,7 +122,7 @@ fetch() {
 
 # List dependencies in the local package cache, in the form $author/$project/$version.
 list_dependencies() {
-	cd "$pkgdir" && find . -type d -depth 3 | sed 's|^./||'
+	cd "$pkgdir" && (find . -type d | grep -E '^\.(\/[^\/]+){3}$' | sed 's|^./||' || :)
 }
 
 # Prune dependencies from the local package cache that don't match the required


### PR DESCRIPTION
Shelm currently uses the depth argument in a `find` call. This argument exists in the macOS implementation of `find`, but does not in Linux implementations. This PR replaces this argument with a filter of all paths removing any that do not include 3 slashes, equivalent to the "--depth 3" argument that currently exists. Because `grep` will fail if this filter does not return a result, I've added a fallback in `|| :` to ensure the function returns nothing if no directories are found, just like the existing script. 

Basically, this change allows shelm to work on both macOS and Linux. 

I've tested this implementation on macOS and an Alpine image, and fetch and make both work the same as how the code exists currently. 